### PR TITLE
Added the WordReference plugin to the default list.

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -145,6 +145,11 @@ Config.DEFAULT_PLUGIN_REPOS = {
         description = "Reader Menu Redesign plugin",
     },
     {
+        owner = "kristianpennacchia",
+        repo = "wordreference.koplugin",
+        description = "WordReference plugin",
+    },
+    {
         owner = "patelneeraj",
         repo = "filebrowserplus.koplugin",
         description = "File Browser Plus plugin",


### PR DESCRIPTION
WordReference plugin repo: https://github.com/kristianpennacchia/wordreference.koplugin

I’ve added versioning support into the `_meta.lua` file.