### PR TITLE
Remove my personal collection from the update list

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -58,13 +58,6 @@ Config.DEFAULT_PATCH_REPOS = {
         owner = "loeffner",
         repo = "KOReader.patches",
         branch = "main",
-        path = "collection", -- patches in subfolder
-        description = "Loeffner's collection patches",
-    },
-    {
-        owner = "loeffner",
-        repo = "KOReader.patches",
-        branch = "main",
         path = "project-title", -- patches in subfolder
         description = "Loeffner's project-title patches",
     },


### PR DESCRIPTION
These are not patches, I want to distribute. 
They are my personal collection of patches from other users adapted to my liking. 
If a user wants them, they should get them from the original repo.