### PR TITLE
Make text scrollable in changelog viewer

### DIFF
--- a/ui_manager.lua
+++ b/ui_manager.lua
@@ -114,7 +114,8 @@ end
 
 function UIManager_Updates:_createChangelogWidget(plugin_name, version, markdown)
     local text = self:_markdownToPlainText(markdown) or _("No changelog available for this version.")
-    return TextViewer:new{
+    local text_viewer
+    text_viewer = TextViewer:new{
         title = T(_("Changelog — %1 (%2)"), plugin_name, version),
         text = text,
         show_menu = false,
@@ -123,11 +124,12 @@ function UIManager_Updates:_createChangelogWidget(plugin_name, version, markdown
             {{
                  text = _("Close"),
                  callback = function()
-                     self:onClose()
+                     text_viewer:onClose()
                  end
              }}
         }
     }
+    return text_viewer
 end
 
 function UIManager_Updates:showPluginChangelog(update)


### PR DESCRIPTION
Replaces the (nonscrollable) `TextBoxWidget` with the `TextViewer` widget to allow text to be scrolled in longer changelog messages.

### Before
<img width="494" height="519" alt="Screenshot_20260208_131226" src="https://github.com/user-attachments/assets/21e9074d-e33d-4e92-b72e-024767bf90f3" alt="TextBoxWidget with content flowing outside of the container" />

### After
<img width="494" height="521" alt="Screenshot_20260208_125227" src="https://github.com/user-attachments/assets/440ce9b6-47e9-413a-ae05-e21d5cd38b52" alt="TextViewerWidget with long content displaying a scrollbar" />


Also fixed a pattern match character that prevented HTML images from being stripped from the output.

The changelog viewer could also use the `HtmlBoxWidget` and `FileConverter:mdToHtml` instead, but would require a little more work for styling.


