### PR TITLE
docs: Fix incorrect DEFAULT_PATCH_REPOS location

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ my-custom-patch
 You can create a pull request to add your repository to the plugin's default repository list. This way, all users will have access to your patches without manual configuration.
 
 1. Fork the Updates Manager plugin repository
-2. Add your repository to `config.lua` in the `DEFAULT_PATCH_REPOS` table
+2. Add your repository to `updatesmanager_config.lua` in the `DEFAULT_PATCH_REPOS` table
 3. Create a pull request with a description of your patches repository
 4. Your PR will be reviewed and merged, making your patches available to all users
 
@@ -284,7 +284,7 @@ return {
 You can create a pull request to add your plugin to the plugin's default repository list. This way, all users will have access to your plugin updates without manual configuration.
 
 1. Fork the Updates Manager plugin repository
-2. Add your plugin repository to `config.lua` in the `DEFAULT_PLUGIN_REPOS` table
+2. Add your plugin repository to `updatesmanager_config.lua` in the `DEFAULT_PLUGIN_REPOS` table
 3. Create a pull request with a description of your plugin
 4. Your PR will be reviewed and merged, making your plugin available to all users
 

--- a/REDDIT_POST.md
+++ b/REDDIT_POST.md
@@ -79,7 +79,7 @@ If you have a plugin that's not in the default list, you can:
 Want to add your patches or plugins to the default list so all users can access them?
 
 1. Fork the [Updates Manager repository](https://github.com/advokatb/updatesmanager.koplugin)
-2. Add your repository to `config.lua` in the appropriate table (`DEFAULT_PATCH_REPOS` or `DEFAULT_PLUGIN_REPOS`)
+2. Add your repository to `updatesmanager_config.lua` in the appropriate table (`DEFAULT_PATCH_REPOS` or `DEFAULT_PLUGIN_REPOS`)
 3. Create a pull request with a description of your repository
 4. Your PR will be reviewed and merged
 


### PR DESCRIPTION
It was moved from config.lua to updatesmanager_config.lua a while ago.

Fixes: dbfec0245ceb ("changed: remove updates.json, fix subprocess stability, update plugin/patches default list")
